### PR TITLE
docs: CLAUDE / RULES / AUDIT / REDESIGN

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,236 @@
+# AUDIT.md
+
+Full audit of the site as it existed before the hygiene PRs merged (August 2026). Preserved as the reference for the redesign work in `REDESIGN.md` and for any future "why did we do that?" questions.
+
+Every finding here has been either shipped in Branch A (see `## Hygiene status`) or scheduled for Branch B (see `REDESIGN.md`).
+
+---
+
+## Table of contents
+
+1. What existed
+2. Software-engineer lens — bugs, dead code, tech debt
+3. UI/UX-engineer lens — flow, hierarchy, accessibility
+4. Copywriter lens — voice, AI-flavour, real errors
+5. CMO lens — proof, funnel, conversion
+6. What was missing
+7. What was overdone
+8. Corrections to public facts
+9. Hygiene status (Branch A)
+10. Sources
+
+---
+
+## 1. What existed
+
+**Routes**
+
+| Route       | Purpose                                                               |
+| ----------- | --------------------------------------------------------------------- |
+| `/`         | Home: hero, logo carousel, achievements, testimonials, resources     |
+| `/about`    | Bio hero (5 paragraphs), education, projects (6), skill bars, speaking |
+| `/branding` | "Brand Experience Initiative" landing page                            |
+| `/model`    | GridIQ electricity dashboard prototype — **unrelated to the site**   |
+
+**Home sections in order:** Navbar → Hero → LogoCarousel ("Organisations Impacted") → Achievements (only 2 items) → Testimonials (5) → Resources (6 cards) → Footer, plus a `BookModal` that auto-opened after 3 s on every visit.
+
+**About sections:** Hero bio (5 paragraphs) → Education + 3 certs → Recent Projects (6) → Skills bars (all 90–96%) + Speaking CTA → Footer. An `Impact` component existed but was commented out.
+
+**Brand tokens:** primary `#f06`, `lightGray #FFD1F7`, secondary `#4c4c4c`; hero background `bg-gray-200`; footer `bg-zinc-800`. Fonts: Avenir (default sans), Averia Serif Libre (display), Poppins, Bai Jamjuree, SK Modernist — **five families loaded**.
+
+**Integrations:** Vercel Analytics wired. Mailchimp `/api/subscribe.ts` existed in Pages-Router format (dead code — the site is App Router). Footer newsletter form used `mailto:` as its submit.
+
+---
+
+## 2. Software-engineer lens
+
+### Critical bugs
+
+1. `/branding` hero **"Get Started"** button had no `href` and no `onClick` — clicks did nothing.
+2. Footer **newsletter** was broken: the input was collected but never sent; "Subscribe" was a `mailto:` link.
+3. Footer **Privacy Policy** link had `href=""` — reloaded the current page.
+4. `/model` route was a **GridIQ dashboard prototype** unrelated to Temitope. It shipped in the bundle and was indexable.
+5. Two navbars (`components/navbar.tsx` and `components/branding/navbar.tsx`); the branding one had its desktop menu **commented out**.
+6. `<Impact />` component existed but was commented out on `/about`.
+7. `layout.tsx` imported `Navbar` but did not render it.
+
+### Housekeeping
+
+- Logo `alt` read `"Tols Logo"` everywhere.
+- ~12 unused images in `/public` (`Consultation.jpg`, `INSTA.jpg`, `MAIME.png`, `YAS BOOK .jpg`, `out now*.jpg`, `market.png`, `pfp-about.jpg`, `profile.png`, `tik-tok.png`, `tiktok.png`, plus a filename with a stray space, plus `handbook.jpg`+`handbook.jpeg` duplicates), and a stray root `grid ig 3.html`.
+- 5 font families loaded → CLS + bytes. Two sans + one serif is enough.
+- Book modal fired at 3 s on every visit for every visitor with no dismissal memory — interrupted even people who came for the book.
+- No `sitemap.xml`, no `robots.txt`, no OG for `/about` or `/branding`.
+- No 404 page, no loading states.
+- `keywords` meta was only four words — weak.
+
+---
+
+## 3. UI/UX-engineer lens
+
+- **Hero was background-heavy, message-light.** `bg-gray-200` fought the hot pink brand. The tagline `Branding | Marketing | Communication | Advertising | Strategy` was a keyword string, not a positioning line.
+- **Two CTAs both went to Selar** ("MEET TEMITOPE" → `selar.com/412292`). The label "MEET TEMITOPE" was misleading — it opened a paid consult page, not an About page.
+- **"Some Of My Projects"** on the home page showed only 2 items and linked "VIEW ALL" to `/about` — but on `/about` the same section was titled "Some Of My projects" (capitalization drift) with 6 items.
+- **Skills as 90–96% bars** is a dated pattern and immediately reads as inflated. Every skill within a 6-point band trained the eye to disbelieve them.
+- **Testimonials carousel** autorotated every 6 s — too fast to finish reading long quotes, no pause indicator, accessibility issue.
+- **Resource cards** all had the same CTA copy ("Connect With Me") on WhatsApp, YouTube and Instagram cards — visually identical, no differentiation.
+- **Book modal at 3 s on every load + `BookPromo` sticky forever** = interruption pattern, hurts trust.
+- **Contrast**: white text on `#FFD1F7` (used in speaking CTA) failed WCAG.
+- No focus rings on custom buttons; `motion.div` transitions on multiple sections caused layout shift on slower devices.
+- Mobile nav was fine, but the WhatsApp CTA in the nav sent users off-site before they'd read anything.
+- The `/branding` page used a purple→hot-pink gradient (`#9a33cc → #ff0066`) that was off-brand from every other page.
+- Navbar "BRANDX" link went to `brandxperience.org` — visitors left the site with no way back.
+
+---
+
+## 4. Copywriter lens
+
+### AI-flavoured / clichéd copy that was on the live site
+
+- "unleashing the true potential of brands"
+- "clear vision and unwavering commitment"
+- "incorporate multiple touchpoints, including digital media, social media, and experiential marketing"
+- "a clear, compelling, and emotionally resonant brand" (tricolon)
+- "align with their customers' values, aspirations, and lifestyles" (tricolon)
+- "deep understanding of consumer behavior and market trends"
+- "carving a path towards becoming an industry leader"
+- "In today's highly competitive market…" (textbook AI opener)
+- "move beyond simple features and functions"
+- "cutting edge solutions" / "rise above the noise"
+- Testimonial 2 (Vivian Efajemue): "strategic genius…amplified our reach exponentially…data-driven campaigns that deliver measurable growth" — the only testimonial that read AI-generated; every other was authentic (uneven grammar, honest voice, personal detail).
+
+### Real typos in live copy
+
+- `CONFERNCE` (should be `Conference`) on the Yantic project.
+- `mastro` (should be `maestro`) and `portraits` used as a verb (should be `portrays`) in two testimonials.
+- Lowercase sentence starts in About: "she has worked…", "she believes in…", "she has a passion".
+- Book modal title said "Authentic Self Handbook" but the public book is "Your Authentic Signature".
+
+### Positioning problems
+
+- Home tagline and About tagline were literally the same line — the site said the same thing twice.
+- **No ownable phrase.** Peer sites (Cassandra Worthy's "Change Enthusiasm®", Michelle Griffin's "Be Seen and Sought After", Lisa Nichols' "Inspire. Lead. Transform.") each own a phrase. Temitope's site did not.
+- Public interviews (TechEconomy Sept 2025, The Upper Ent Sept 2025) contained much stronger quotable lines she has actually said — none of them appear on the site:
+  - "A brand without story is an empty shell."
+  - "The biggest mistake is treating personal branding like a CV — a list of past achievements rather than a living narrative."
+  - "For African creators, the goal is not to echo the West, but to stand out and shape culture on our own terms."
+
+---
+
+## 5. CMO lens
+
+- **Zero named clients above the fold.** Real engagements exist (NECCI, PerformX, Yantic, American Spaces, TEDxSamaru, MYFICON, Masterpiece Impact) — none appeared as a "featured in / worked with" logo bar under the hero.
+- **No media bar.** She was covered by TechEconomy and The Upper Ent in September 2025 — no "As seen in" strip.
+- **Quantifiable results were hidden.** "Trained 2,000 people across 22 states in 6 weeks" was buried inside project #6 on the About page. That is a headline statistic. Same with "Mentored ~700 university students across Babcock, Ibadan, OAU".
+- **No dedicated Speaking page** with topics, one-sheet PDF, reel, or booking form with qualifying fields.
+- **No dedicated Book page.** The book existed only as a 3-second modal. Modals break sharing, SEO and retargeting.
+- **No dedicated Resources page.** The "Resources" nav link scrolled to a home section. Peers (Mel Robbins, Rachel Rodgers, Cy Wakeman) all have `/resources` as its own hub.
+- **Funnel routed everything to WhatsApp or Selar.** No email capture, no CRM, no nurture sequence.
+- **Brand Xperience metrics** (1,000+ trained, 20,000+ community, 95% recommendation, 500+ WhatsApp members, 50+ cohorts, 10+ countries) were not surfaced on the personal site.
+- **No press kit / bio download / high-res headshots** — event planners need these on a single click.
+
+---
+
+## 6. What was missing entirely
+
+Sections / pages that should exist and don't:
+
+1. `/speaking` (topics, reel, one-sheet, booking form)
+2. `/books/your-authentic-signature` (dedicated book page + free-chapter opt-in)
+3. `/resources` (real page, filterable library, gated lead magnet)
+4. `/press` (features grid, downloadable press kit)
+5. `/work` / case studies (NECCI, PerformX, American Spaces, Yantic told as narratives with outcomes)
+6. `/contact` (proper form with intent routing — Speak / Consult / Media / Other — not just a WhatsApp link)
+7. `/programs` (folds the current `/branding` into a broader hub with SPROUT, BrandUp, Resonance Blueprint, Own Your Name, The Influence Code)
+
+Content missing:
+
+- **Signature framework** — she teaches "Define values → Communicate with clarity → Consistently deliver" (from TEDxSamaru). This is her IP; the site never states it.
+- **Nigerian heritage & POV** — Luvvie Ajayi Jones's playbook. Currently absent.
+- **Newsletter with subscriber count** as social proof.
+- **Podcast episodes** (Brand Xperience podcast is referenced but not surfaced).
+- **Featured pull quotes** from the two September 2025 press interviews.
+- **Editorial photography** — one professional shoot with dramatic lighting; the current headshot is fine but used everywhere.
+
+---
+
+## 7. What was overdone
+
+- Five font families.
+- Animation-on-every-section that added cost and delayed LCP.
+- 3-second auto-modal + persistent `BookPromo` + WhatsApp nav button + inline resource CTAs = **four competing hooks** on the same fold.
+- Skill bars, "Some Of My Projects" title appearing twice under different capitalizations, and the same tagline on Home and About.
+
+---
+
+## 8. Corrections to public facts
+
+Verified from public sources and locked into `RULES.md`:
+
+1. Her ventures are **Elegance Inspired Limited** (agency, founded 2021) and **Brand Xperience** (learning arm, `brandxperience.org`) — plus mentoring/instructor roles at Dream Center Trybe and O2 Academy. She is **not** associated with BrandDrive (a separate Nigerian fintech led by Ndu Ekwomadu).
+2. The book is **"Your Authentic Signature"** (subtitle *A Personal Branding Handbook*). No ISBN found; appears to be a self-published digital handbook available on Selar.
+3. Two strong recent press pieces: **TechEconomy 22 Sept 2025** and **The Upper Ent 16 Sept 2025**. Both are quotable.
+4. **No "40 Under 40"** or major-award recognition was findable in public sources — do not fabricate one.
+5. Education (verified): BSc Human Anatomy (Ahmadu Bello University, Zaria) → MSc Marketing and Sales (Rome Business School, Rome) → Brand Management + Digital Marketing certifications (London School of Business Administration) → Agile/Scrum certification (Agillant Group, North Carolina).
+6. Recurring positioning line: **"I shape how African brands show up, grow and succeed."** (from her IG bio and homepage).
+7. Signature framework (from TEDxSamaru): **Define your values → Communicate with clarity → Consistently deliver on your promises.**
+8. Brand Xperience self-reported metrics we may quote: 1,000+ trained professionals, 20,000+ community members, 500+ WhatsApp community, 50+ cohorts run, 10+ countries reached, 95% recommendation rate, 98% satisfaction rate.
+9. Real named events: TEDxSamaru (~Sept 2025), NECCI PR Roundtable 24th ed. (2024, "Women In Technology: Breaking Barriers"), PerformX Summit / Akin Akinpelu Conference (2025), Upgrade Marketing Conference 2025 ("Marketing is not a Department"), American Spaces Nigeria training tour (2023 — 2,000+ trained across 22 states in 6 weeks), MYFICON (Abuja International Conference Centre), Masterpiece Impact Africa launch (2025).
+10. Birthdate, birthplace and personal-life details are **unknown from public sources**. Do not infer them.
+
+---
+
+## 9. Hygiene status (Branch A — merged August 2026)
+
+17 GitHub issues shipped across three PRs, all squash-merged into `main`:
+
+**PR #32 — Copy fixes** (5 issues: #5, #7, #8, #9, #12)
+
+- Logo alt text corrected across navbar, mobile navbar, footer.
+- Testimonial typos fixed (`portraits` → `portrays`, `mastro` → `maestro`) with light grammar cleanup.
+- Yantic project role: `UPGRADE MARKETING CONFERNCE` → `Upgrade Marketing Conference`.
+- Book modal + promo renamed to "Your Authentic Signature".
+- Home Achievements section renamed to "Featured Work"; button "SEE ALL PROJECTS" now targets `/about#projects`.
+- About section title casing fixed.
+- Hero pipe-string tagline replaced with kicker + H1 + supporting line.
+
+**PR #33 — Content rewrites + cleanup** (6 issues: #6, #10, #11, #14, #15, #16)
+
+- About bio rewritten from 5 AI-flavoured paragraphs to 3 evidence-first paragraphs.
+- `/branding` intro rewritten (opener dropped, tricolons removed).
+- `Impact` component deleted; import removed from `/about`.
+- 13 orphan public assets + `grid ig 3.html` + duplicate `handbook.jpeg` deleted.
+- Poppins + Bai Jamjuree font imports removed; `Button` base moved to `font-sans`.
+- Duplicate `branding/navbar.tsx` deleted; `/branding` now uses the main navbar.
+- Net: 958 lines removed, 37 added.
+
+**PR #34 — Broken UX + SEO infra** (6 issues: #2, #3, #4, #13, #17, #18)
+
+- Newsletter migrated from Pages-Router `src/api/subscribe.ts` to App-Router `src/app/api/subscribe/route.ts`; footer form now submits via `fetch` with proper success / error states.
+- `/privacy` page created with a plain-language policy; footer link fixed.
+- `/branding` "Get Started" button now smooth-scrolls to a new `#what-we-offer` anchor.
+- `/model` route deleted.
+- `src/app/sitemap.ts`, `src/app/robots.ts`, `src/app/not-found.tsx` added.
+- Root metadata expanded (broader keywords, `metadataBase`); unique metadata for `/about` and `/branding` via sibling `layout.tsx` server components.
+- `BookModal` session-gated: opens once per browser session, only after scroll > 400 px or 4 s elapsed.
+
+---
+
+## 10. Sources
+
+Public sources used to author copy and verify facts. Cite one of these in commit messages when introducing new claims.
+
+- <https://www.temitoperuthjacob.com/> and <https://www.temitoperuthjacob.com/about/>
+- <https://www.instagram.com/brandingqueen2/>
+- <https://ng.linkedin.com/in/temitoperuthjacob>
+- <https://ng.linkedin.com/company/elegance-branding>
+- <https://www.eleganceinspired.org/>
+- <https://www.brandxperience.org/>
+- <https://techeconomy.ng/personal-branding-in-your-40s-moving-from-execution-to-influence-a-sequel-with-temitope-ruth-jacob/>
+- <https://theupperent.com/2025/09/16/the-brand-queen-speaks-temitope-ruth-jacob-on-authenticity-identity-and-the-future-of-african-branding/>
+- <https://tribuneonlineng.com/necci-pr-roundtable-2024-issues-as-women-set-to-discuss-technology/>
+- <https://thenationonlineng.net/expert-launches-initiative-to-empower-professionals/>
+- <https://www.facebook.com/KreativeInnovators/posts/122151358868624061/>
+- <https://guardian.ng/business-services/akinpelu-launches-performx-nexus-to-bridge-strategy-execution-gap/>
+
+Reference sites used for the Branch B redesign brief are listed in `REDESIGN.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,179 @@
+# CLAUDE.md
+
+Project context for future Claude Code / AI-assisted sessions on this repository. Read this first.
+
+---
+
+## What this repo is
+
+Personal website for **Temitope Ruth Jacob** — a Nigerian brand strategist, speaker and author based in Abuja. She is the founder and CEO of **Elegance Inspired Limited** and the convener of **Brand Xperience**, its learning arm.
+
+Live at: <https://www.temitoperuthjacob.com>
+Deploy target: Vercel (see `vercel.json`).
+
+The site serves five jobs, in priority order:
+
+1. Authority-building portfolio for a speaker + consultant.
+2. Book marketing landing page (*Your Authentic Signature*).
+3. Free + paid resource hub.
+4. About/bio and social-proof hub.
+5. Speaking + consulting inquiry funnel.
+
+---
+
+## Tech stack
+
+- **Framework:** Next.js 14 (App Router). Do not add Pages Router routes — the previous `src/api/subscribe.ts` was a broken Pages-style file and was migrated to `src/app/api/subscribe/route.ts`.
+- **Language:** TypeScript 5.
+- **Styling:** Tailwind CSS + a small shadcn/ui footprint (`src/components/ui/`).
+- **Motion:** Framer Motion.
+- **Icons:** `lucide-react` + `react-icons/fa6`.
+- **Analytics:** `@vercel/analytics/next`.
+- **Newsletter:** Mailchimp via the `/api/subscribe` route.
+- **Package manager:** npm (a `package-lock.json` is checked in).
+
+Local dev:
+
+```bash
+npm install
+npm run dev       # http://localhost:3000
+npm run build
+npm run start
+npx tsc --noEmit  # type-check without emitting
+```
+
+---
+
+## Directory map
+
+```
+src/
+  app/
+    layout.tsx                # Root metadata + fonts + Analytics
+    page.tsx                  # Home (hero, logo carousel, achievements, testimonials, resources)
+    about/
+      layout.tsx              # About page metadata (added because the page is a client component)
+      page.tsx                # Long-form bio (currently 3 paragraphs — see RULES.md)
+    branding/
+      layout.tsx              # /branding metadata
+      page.tsx                # Brand Experience Initiative (will be renamed → /programs in Branch B)
+    privacy/
+      page.tsx                # Privacy policy
+    api/
+      subscribe/route.ts      # Mailchimp POST endpoint (App Router)
+    sitemap.ts                # Dynamic sitemap
+    robots.ts                 # Robots policy
+    not-found.tsx             # Custom 404
+    globals.css               # CSS vars + custom hover states
+  components/
+    navbar.tsx                # Only navbar; a second /branding navbar was deleted
+    hero.tsx                  # Home hero (kicker + H1 + CTAs)
+    logo-carousel.tsx         # "Organisations Impacted" strip
+    achievements.tsx          # Home "Featured Work" (2 items)
+    testimonials.tsx          # Rotating testimonial pairs, 6s interval
+    resources.tsx             # Horizontal resource carousel — will become /resources in Branch B
+    book-modal.tsx            # Session-gated modal + BookPromo sticky
+    footer.tsx                # Dark footer with working newsletter form
+    about/                    # Sub-components for /about
+    ui/                       # Small shadcn primitives
+  lib/utils.ts                # cn() helper
+public/
+  fonts/                      # Local font files (Avenir, Averia, SK Modernist)
+  *.png/*.jpg                 # Images (all orphans cleaned in hygiene PR #33)
+tailwind.config.ts            # Tokens + fontFamily
+vercel.json
+```
+
+Key files to open first when working on the site: `src/app/layout.tsx`, `src/app/page.tsx`, `src/components/hero.tsx`, `src/components/footer.tsx`, `tailwind.config.ts`.
+
+---
+
+## Brand tokens (current — pre-Branch B)
+
+Palette (from `tailwind.config.ts` + `globals.css`):
+
+| Token          | Value       | Used for                                    |
+| -------------- | ----------- | ------------------------------------------- |
+| `primary`      | `#f06`      | CTAs, section fills, accent highlights      |
+| `secondary`    | `#4c4c4c`   | Body text, headings                         |
+| `secondary-2`  | `#797979`   | Muted text                                  |
+| `lightGray`    | `#FFD1F7`   | Soft pink surface (misnamed; not gray)      |
+| `--primary`    | `102,37,103`| Deep purple (used only for `text-primary-dark`) |
+
+Fonts (loaded in `layout.tsx`):
+
+| Family              | Kind        | Where used                        |
+| ------------------- | ----------- | --------------------------------- |
+| Avenir              | Local sans  | Default `font-sans` — most body   |
+| Averia Serif Libre  | Local serif | `font-serif` — display headlines  |
+| SK Modernist        | Local sans  | `font-sk-modernist` — /branding page only |
+
+Poppins and Bai Jamjuree were removed in PR #33. Do not re-add fonts without justification.
+
+Redesign palette (Branch B — see `REDESIGN.md`):
+
+```
+--bg-cream:      #FAF6F1
+--ink:           #1A1614
+--rose:          #D4756B
+--blush:         #F4DDD5
+--aubergine:     #3D1F2E
+--brand-pink:    #F06   (kept as equity; logo/monogram only)
+```
+
+---
+
+## Environment variables
+
+Required in production for the newsletter to succeed:
+
+- `MAILCHIMP_API_KEY`
+- `MAILCHIMP_AUDIENCE_ID`
+- `MAILCHIMP_SERVER_PREFIX` (e.g. `us21`)
+
+If any are missing, `/api/subscribe` returns `{"error":"Newsletter is not configured"}` with status 500, and the footer form shows an inline error.
+
+---
+
+## Third-party links currently used on the site
+
+- Book / consultation sales: `selar.com/412292`, `selar.com/1v4g42`.
+- WhatsApp: `wa.link/dtys70`, plus community `chat.whatsapp.com/…`.
+- Content: YouTube `@thebranding_queen`, Instagram `@brandingqueen2`, Medium `temitoperuthjacob.medium.com`.
+- Adjacent properties: `eleganceinspired.org`, `brandxperience.org`.
+
+Prefer routing new CTAs through the site's own pages (`/speaking`, `/books/…`, `/contact`) once Branch B lands, rather than pushing users off to external platforms as the first step.
+
+---
+
+## Branch strategy
+
+- `main` — production. Every merge is a squash-merge with the PR title as the commit message.
+- `hygiene/*` — three PRs, all merged: #32 copy fixes, #33 rewrites + cleanup, #34 broken UX + SEO.
+- `redesign/*` — will land after Branch A. See `REDESIGN.md` for the plan and the 13 filed GitHub issues (#19–#31).
+- `docs/*` — non-code docs like this file.
+
+---
+
+## Roadmap at a glance
+
+1. ✅ **Branch A — Hygiene** (merged): fix broken things, remove AI-flavoured copy, delete dead code, wire the newsletter, add SEO plumbing.
+2. ⏭ **Branch B — Redesign** (next): new IA with 6+ new pages (`/speaking`, `/books/…`, `/resources`, `/programs`, `/work`, `/press`, `/contact`), cream + rose palette, two-font system, session-only book modal, richer social proof. See `REDESIGN.md`.
+3. **Later** — editorial photography drop-in, real testimonials with photos, podcast surfacing.
+
+---
+
+## When you are working on this repo
+
+- Read `RULES.md` before writing new copy or adding components. It captures decisions we made specifically because of previous mistakes on this site (AI-flavoured copy, orphan assets, broken forms, dated design patterns).
+- Read `AUDIT.md` if you need the "why" behind a decision or want to check whether an issue has already been noted.
+- Read `REDESIGN.md` before making any visual / IA change — Branch B has an approved plan; don't freelance a redesign.
+- All facts about Temitope on the site come from public sources (her site, LinkedIn, IG bio, TechEconomy Sept 2025 interview, The Upper Ent Sept 2025 interview). Do not invent titles, awards, dates, or clients.
+
+---
+
+## Contact for questions
+
+- Site domain: `temitoperuthjacob.com`.
+- Repo owner: `Nwanne-san`.
+- Design credit in footer: Nwanne Nnamani (`nwanne-san.vercel.app`).

--- a/REDESIGN.md
+++ b/REDESIGN.md
@@ -1,0 +1,268 @@
+# REDESIGN.md
+
+Branch B plan. This is what we will build after all Branch A hygiene PRs merge. Every decision here is reflected in one of the 13 GitHub issues #19–#31.
+
+---
+
+## Scope in one paragraph
+
+Turn the site from a one-page portfolio with a homepage-scrolling "resources" strip into a proper 8-page authority site for a speaker + author + consultant. Ground the brand palette (cream + dusty rose, hot pink kept as small equity only), collapse to two font families, kill the intrusive book modal, add real proof (media logos, named clients, quantified impact), and give event planners a dedicated `/speaking` page with a booking form and downloadable one-sheet.
+
+---
+
+## Information architecture
+
+Current (5 pages, one of which is orphaned):
+
+```
+/            /about        /branding        /model            /privacy
+                                            (unrelated,       (added in
+                                             deleted in       Branch A)
+                                             hygiene)
+```
+
+Target (8 pages, all in the main nav or footer):
+
+```
+/                          Home
+/about                     About — long-form (~1,700 words)
+/speaking                  Speaking — topics + reel + one-sheet + booking form
+/work                      Work — case studies index → /work/[slug]
+/books                     Books — index → /books/your-authentic-signature
+/programs                  Programs — Brand Xperience programs (SPROUT, BrandUp, etc.)
+/resources                 Resources — filterable library + lead magnet
+/press                     Press — media features + downloadable kit
+/contact                   Contact — routed form (Speak / Consult / Media / Other)
+/privacy                   (kept)
+```
+
+Main nav shrinks to: **About · Speaking · Books · Programs · Resources · Contact**.
+Work and Press live in the footer and are linked from About and Home.
+
+Redirects: `/branding` → 301 `/programs`.
+
+---
+
+## Brand palette migration
+
+Keep hot pink as **equity**, not as dominant colour.
+
+```
+--bg-cream:      #FAF6F1   (page background)
+--ink:           #1A1614   (body text)
+--rose:          #D4756B   (accent — buttons, monograms, date markers)
+--blush:         #F4DDD5   (surface tints)
+--aubergine:     #3D1F2E   (footer, section dividers)
+--brand-pink:    #F06      (kept — logo, monogram, one hero highlight only)
+```
+
+Section mapping:
+
+| Current                                | Target                              |
+| -------------------------------------- | ----------------------------------- |
+| Hero `bg-gray-200`                     | `bg-cream`                          |
+| Testimonials `bg-primary` (#f06)       | `bg-blush` + rose accent            |
+| Education `bg-primary`                 | `bg-cream` + rose divider           |
+| Speaking CTA `bg-[#FFD1F7]`            | `bg-blush`                          |
+| Footer `bg-zinc-800`                   | `bg-aubergine`                      |
+| `/branding` gradient `#9a33cc→#ff0066` | Removed on refactor to `/programs`  |
+
+All text/background combinations must pass WCAG AA. White on `#FFD1F7` (the current speaking CTA) fails — retire it.
+
+---
+
+## Typography
+
+From 3 families down to 2:
+
+- **Display serif:** Fraunces (variable, warm, character-rich) or Cormorant Garamond.
+- **Body sans:** Inter, or keep Avenir if the local font license is confirmed.
+
+Drop: Averia, SK Modernist.
+
+Type scale defined in `tailwind.config.ts` fontSize extension. Use `font-serif` for display + eyebrow labels only; `font-sans` for everything else.
+
+---
+
+## Page-by-page specs
+
+### `/` Home (issues #21, #22, #23)
+
+Sections in order:
+
+1. **Hero.** Headshot left. Right side: kicker `BRAND STRATEGIST · SPEAKER · AUTHOR`, H1 *"I shape how African brands show up, grow and succeed."* (already shipped in Branch A), supporting sentence, two distinct CTAs — `Book Temitope to speak` → `/speaking` and `Read the handbook` → `/books/your-authentic-signature`. Drop the WhatsApp button from the nav — replace with `Contact`.
+2. **Media & partners bar.** "Featured in / Worked with": TechEconomy, The Upper Ent, NECCI PR Roundtable, PerformX, Yantic, American Spaces, TEDxSamaru, Masterpiece Impact.
+3. **Signature framework.** Three-column card: *Define your values · Communicate with clarity · Consistently deliver on promises.* (from TEDxSamaru).
+4. **Impact strip.** Four stats, each with a source link:
+   - `2,000+` trained across `22 states, 6 weeks` — American Spaces
+   - `~700` university students mentored — Babcock, Ibadan, OAU
+   - `20,000+` Brand Xperience community
+   - `10+` countries reached
+5. **Featured work.** 3 case-study cards → `/work/[slug]`.
+6. **Book pitch.** Cover + one-line promise + free-chapter opt-in + "Read more" → `/books/your-authentic-signature`.
+7. **Testimonials.** 3 rotating, each with photo + name + org logo. Drop the AI-flavoured one; keep the authentic four.
+8. **Pull quote from press.** *"A brand without story is an empty shell."* (The Upper Ent, Sept 2025).
+9. **Newsletter.** Working capture (already shipped in Branch A hygiene) — surface subscriber count once >1k.
+10. **Footer.** Real links, working Privacy Policy (shipped), full sitemap.
+
+Killed: the auto-triggered `BookModal` on the home page. Session-gate is fine as a transitional layer but the real replacement is the dedicated book pitch section + `/books/…` page.
+
+### `/about` (issue #24)
+
+Rewrite to ~1,700 words, 7 sections:
+
+1. Positioning statement (1 sentence).
+2. Origin story — Zaria → BSc Human Anatomy at ABU → pivot to marketing → MSc at Rome Business School → London certifications → founding Elegance Inspired (2021).
+3. Ventures — Elegance Inspired, Brand Xperience, Dream Center Trybe, O2 Academy.
+4. Signature framework (expanded).
+5. Sectors and clients — tech, fashion, real estate, healthcare, consumer goods.
+6. Recognition and press — TechEconomy, Upper Ent, Tribune, The Nation (with links).
+7. Nigerian identity paragraph — quote from her IG post: *"For African creators, the goal is not to echo the West, but to stand out and shape culture on our own terms."*
+
+Delete the 90–96% skill bars. Replace with a short "How I work" block (3–4 bullets).
+Add a downloadable press kit link + "Book Temitope to Speak" CTA at the bottom.
+
+### `/speaking` (issue #26)
+
+Model: Luvvie Ajayi Jones's `/speaking`.
+
+- Hero with on-stage photo + booking CTA.
+- 3 signature topics (draft):
+  1. Personal Branding in Your 40s: From Execution to Influence.
+  2. African Brands, Global Stages: Building on Our Own Terms.
+  3. The Authentic Signature Framework.
+- 60–90 s video reel (placeholder OK at launch).
+- Named past events grid: TEDxSamaru, NECCI PR Roundtable, PerformX Summit, Upgrade Marketing Conference, MYFICON.
+- 3 speaker testimonials.
+- Booking form with qualifying fields: name, org, event, date, audience size, budget range, format (keynote / workshop / panel), notes. Submits to `/api/contact` (new endpoint or Resend).
+- Downloadable one-sheet PDF + high-res headshots pack link.
+
+### `/books` and `/books/your-authentic-signature` (issue #27)
+
+- `/books/page.tsx` — grid of books (one for now).
+- `/books/your-authentic-signature/page.tsx` — cover, one-line promise, buy/download button (Selar), 150-word synopsis, TOC, sample-chapter email gate, endorsements (placeholder), author block, related resources (framework + podcast).
+- After this ships, remove the `BookModal` from `/` entirely.
+
+### `/programs` (issue #28)
+
+Fold `/branding` into `/programs`. Keep the "Key Components", "Who Is This For", "Benefits" and "Meet the Convener" content. Add cards for the five named programs from `brandxperience.org`:
+
+- **SPROUT** — personal branding conversation.
+- **BrandUp** — personal branding course.
+- **Resonance Blueprint** — strategy masterclass.
+- **Own Your Name** — university tour program.
+- **The Influence Code** — conference with guest speakers.
+
+Each card: what it is · who it's for · format · outcome · CTA.
+
+Set `/branding` → 301 redirect to `/programs` in `next.config.mjs`.
+
+### `/resources` (issue #25)
+
+Model: Mel Robbins's `/downloads`.
+
+- Hero: "Free tools to build your personal brand".
+- Featured lead magnet: *Your Authentic Signature* free first chapter, email-gated → `/api/subscribe`.
+- Filter tabs: All · Free downloads · Articles · Podcast · Videos · Book chapters · Speaking clips · Community.
+- Card grid — initial content:
+  - Article — "Personal Branding in Your 40s" (TechEconomy).
+  - Article — "The Future of African Branding" (Upper Ent).
+  - Video — TEDxSamaru clip.
+  - Community — WhatsApp, Instagram, LinkedIn.
+  - Paid — Personal Branding Consultation (Selar), full handbook (Selar).
+
+Update the `Resources` nav link to `/resources` (currently scrolls to a homepage anchor).
+
+### `/work` and `/work/[slug]` (issue #29)
+
+- `/work/page.tsx` — grid of case studies.
+- `/work/[slug]/page.tsx` template with sections: Client · Challenge · Approach · Outcome · Testimonial (if any).
+- 3 initial case studies: `necci-pr-roundtable-2024`, `performx-summit-2025`, `american-spaces-2023`. All facts must come from her About page or press.
+
+### `/press` (issue #30)
+
+- Press features grid: TechEconomy, Upper Ent, Tribune, The Nation. Each is a clickable quote card.
+- Downloadable press kit (bio + high-res headshots + logos pack) — placeholder link OK at launch.
+
+### `/contact` (issue #30)
+
+- Routed form with intent radio: **Speak / Consult / Media / Other**.
+- Fields: name, org, email, message. Submits to `/api/contact`.
+- Contact details block (email `hi@temitoperuthjacob.com`, phone, Abuja, socials).
+
+---
+
+## Global changes (issues #18, #19, #20)
+
+- **Palette** — introduce the new tokens above; migrate section fills.
+- **Typography** — drop to 2 families; add type scale.
+- **Nav** — 6-item main nav; `Contact` replaces the WhatsApp button.
+- **Footer** — reflect the new IA; keep the working newsletter and Privacy Policy.
+
+---
+
+## Sequencing
+
+Roughly 4–5 PRs, each carrying 2–4 of the redesign issues:
+
+1. **PR B1 — Foundations.** Palette + fonts + nav refactor + updated footer (#18, #19, #20).
+2. **PR B2 — Home rebuild.** Media bar, impact strip, framework, featured work, book pitch, killed modal (#21, #22, #23).
+3. **PR B3 — About + Programs.** Long-form About rewrite + `/programs` refactor (#24, #28).
+4. **PR B4 — Speaking + Books + Resources.** Three new content pages (#25, #26, #27).
+5. **PR B5 — Work + Press + Contact.** Case studies template + press page + routed contact form (#29, #30).
+
+Each PR must run `npx tsc --noEmit` clean, must ship with unique metadata for every new route (see `RULES.md`), and must be added to `src/app/sitemap.ts`.
+
+---
+
+## Reference sites and templates
+
+For visual and structural reference during Branch B. Do not copy pixel-for-pixel; use these to check hierarchy and section presence.
+
+Personal brand sites:
+
+- Luvvie Ajayi Jones — <https://luvvie.org/> (the closest structural analogue)
+- Michelle B. Griffin — <https://michellebgriffin.com/> (three-pillar frame)
+- Bola Sokunbi — <https://www.bolasokunbi.com/> (Nigerian speaker, minimalist)
+- Mel Robbins — <https://www.melrobbins.com/downloads/> (resources page reference)
+- Cassandra Worthy — <https://cassandraworthy.com/> (IP-first positioning)
+- Rachel Rodgers / Hello Seven — <https://helloseven.co/about/> (long-form About)
+- Bozoma Saint John — <https://bozomasaintjohn.com/> (editorial hero)
+- Jay Shetty — <https://jayshetty.me/> (newsletter with subscriber count)
+
+Speaker one-sheets:
+
+- Neen James — <https://neenjames.com/wp-content/uploads/2022/01/NeenJames-Two-Pager-2022.pdf>
+- Chandler Bolt — <https://elitespeakersagency.com/wp-content/uploads/2019/06/Chandler-Bolt-Speaker-Kit.pdf>
+
+Author book pages:
+
+- Emily Henry — <https://emilyhenrybooks.com/>
+- Taylor Jenkins Reid — <https://taylorjenkinsreid.com/books/>
+- Logan Ury — <https://loganury.com/>
+
+Templates to consult if we ever consider a rebuild rather than in-place:
+
+- Framer **Presence** (Medium Rare) — <https://mediumrare.shop/templates/presence-webflow-personal-public-speaker-resume-template> — closest structural match, ~$49.
+- Squarespace **Perfectionist** (Applet Studio) — <https://www.applet.studio/shop/p/squarespace-template-perfectionist> — ~$189, has a Resources page baked in.
+
+---
+
+## Things we are explicitly not doing in Branch B
+
+- Not commissioning new photography inside Branch B — placeholder assets are fine; the photo drop-in is a later pass.
+- Not adding a full CMS. Case studies, resources, programs are hand-authored object literals or MDX. A CMS is out of scope until content volume justifies it.
+- Not changing the deploy target. Vercel stays.
+- Not touching Elegance Inspired or Brand Xperience sub-sites. This repo is only `temitoperuthjacob.com`.
+
+---
+
+## Definition of done for Branch B
+
+- All 13 redesign issues (#19–#31) closed.
+- Home, About, Speaking, Books, Programs, Resources, Work, Press, Contact all live and reachable from the main nav or footer.
+- No page uses the old `#F06`-as-fill pattern; hot pink appears in logo + one hero highlight only.
+- No hard-loaded font other than the two selected families.
+- Every route in the sitemap.
+- Newsletter (already working after Branch A) still works.
+- `npx tsc --noEmit` clean, `npm run build` clean, no console warnings on the deployed preview.

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,140 @@
+# RULES.md
+
+Working rules for this repo. Each rule exists because we already had the opposite in production and it caused a problem. Break these only with a written reason.
+
+---
+
+## Copy rules
+
+### Do not use AI-flavoured phrasing
+
+Every one of these was on the site in some form before the hygiene PRs. Do not reintroduce them or their close relatives:
+
+- "unleashing the true potential"
+- "clear vision and unwavering commitment"
+- "incorporate multiple touchpoints"
+- "clear, compelling, and emotionally resonant" (or any tricolon of adjectives)
+- "align with values, aspirations, and lifestyles" (or any tricolon of nouns)
+- "deep understanding of consumer behavior"
+- "carving a path towards becoming an industry leader"
+- "In today's highly competitive market"
+- "move beyond simple features and functions"
+- "cutting edge solutions"
+- "rise above the noise"
+- "seamless / seamlessly"
+- "unlock / unleash"
+- "amplified our reach exponentially"
+- "data-driven campaigns that deliver measurable growth" (without any actual numbers)
+
+Prefer: short declarative sentences, concrete numbers, named clients, named events, verbatim quotes from her interviews.
+
+### Do not stack keywords as a tagline
+
+`Branding | Marketing | Communication | Advertising | Strategy` is not a positioning line — it is a keyword list. Every headline must be a real sentence.
+
+The footer subtitle still contains a similar pipe string (`Personal Branding | Marketing | ...`); it will be rewritten in Branch B. Do not clone the pattern elsewhere in the meantime.
+
+### Do not duplicate the same tagline twice on the page
+
+Home and About previously both used "shaping how African brands grow, show up & succeed" verbatim, in adjacent positions. Vary the wording; don't repeat.
+
+### Do not invent facts about Temitope
+
+Every claim on the site must be verifiable from a public source. The canonical sources today are:
+
+- Her homepage and `/about` page.
+- Her Instagram bio (`@brandingqueen2`) and LinkedIn (`ng.linkedin.com/in/temitoperuthjacob`).
+- TechEconomy interview (22 September 2025): "Personal Branding in Your 40s: Moving from Execution to Influence".
+- The Upper Ent interview (16 September 2025): "The 'Brand Queen' Speaks".
+- The `brandxperience.org` and `eleganceinspired.org` sites.
+
+Specifically:
+
+- Her ventures are **Elegance Inspired Limited** (agency) and **Brand Xperience** (learning arm). She is **not** associated with BrandDrive; do not conflate.
+- The book title is **"Your Authentic Signature"**. Do not use "Authentic Self Handbook" or any variant.
+- No verified "40 Under 40" or major-award recognition exists in public sources — do not fabricate one.
+- Birthdate, birthplace and personal-life details are not public — do not invent them. Mark any unconfirmed detail `[NEEDS CONFIRMATION]` inline.
+
+### Fix typos when you see them
+
+Real typos still on the site before the hygiene PRs and now fixed:
+
+- `CONFERNCE` → `Conference`
+- `mastro` → `maestro`
+- `portraits` (as verb) → `portrays`
+- Lowercase "she" at sentence starts in the About bio.
+
+If you see similar issues, fix them; don't leave them for later.
+
+### Sentence-case headings; no ALL-CAPS bodies
+
+Section titles are Title Case ("Featured Work"), not screaming caps ("FEATURED WORK"). Small kickers, button labels and eyebrow labels can be uppercase — reserve caps for typographic emphasis, not paragraphs.
+
+---
+
+## Fact-check rules
+
+- If you need a stat, cite where it came from in the commit message or PR body.
+- Real numbers we currently have permission to use: **2,000+** trained across 22 states in 6 weeks (American Spaces, 2023); **~700** university students mentored (Babcock, Ibadan, Obafemi Awolowo University); Brand Xperience self-reported: 1,000+ trained professionals, 20,000+ community members, 500+ WhatsApp community, 50+ cohorts, 10+ countries, 95% recommendation rate, 98% satisfaction rate.
+- Do not add fabricated percentages or client counts. The old 90–96% "skill bars" in the About page will be deleted in Branch B for exactly this reason.
+
+---
+
+## Image rules
+
+- Every `<Image>` needs a descriptive `alt` attribute. Use `alt=""` only for purely decorative images and always with intent.
+- The logo alt is `"Temitope Ruth Jacob"`. Do not use `"Tols Logo"`, which was a placeholder.
+- Do not add images to `/public` that are not referenced in `src/`. The hygiene PR removed 13 orphan assets; do not reintroduce that pattern. Delete on rename.
+- Prefer WebP or AVIF over JPG for new photos. Reuse `next/image` optimisation.
+
+---
+
+## Component rules
+
+- **One navbar.** `src/components/navbar.tsx` is the only navbar file. If a page needs a variant, add a prop — do not fork the file. The former `src/components/branding/navbar.tsx` (which had its whole menu commented out) has been deleted.
+- **No auto-modals without a session gate.** The `BookModal` opens at most once per browser session and only after the visitor scrolls past 400px or spends 4s+. Any new modal must follow the same rule.
+- **Metadata belongs on server components.** If a route needs unique metadata but the page is `"use client"`, add a sibling `layout.tsx` server component that exports `metadata` (see `src/app/about/layout.tsx` and `src/app/branding/layout.tsx`).
+- **Avoid Pages Router.** All new API routes go in `src/app/api/<name>/route.ts`, not `src/pages/api/`.
+- **Font families cap.** We are down to 3 (Avenir, Averia, SK Modernist). Branch B will drop to 2. Do not add a fourth family without a strong reason.
+
+---
+
+## Brand token rules
+
+- `#F06` (hot pink) is brand equity. After Branch B, it is reserved for the logo, monogram and one hero highlight only — not section fills.
+- The Branch B palette is cream `#FAF6F1` background, ink `#1A1614` text, rose `#D4756B` accent, blush `#F4DDD5` surface, aubergine `#3D1F2E` for footer/dividers.
+- Do not use the `/branding` page's purple→pink gradient (`#9a33cc → #ff0066`) anywhere else. It is off-brand and will be removed when `/branding` is refactored into `/programs`.
+- Contrast: verify WCAG AA on every text/background combination. White text on `#FFD1F7` (the misnamed `lightGray`) failed contrast in the pre-hygiene site.
+
+---
+
+## SEO rules
+
+- Every route must have a unique `<title>` and `<meta name="description">`. Home + `/about` + `/branding` + `/privacy` are covered; new routes must add either a `metadata` export or a `layout.tsx` that exports one.
+- Every route must be listed in `src/app/sitemap.ts` unless intentionally excluded.
+- Every route must be reachable from the main nav or the footer.
+- `alt` text on images is not just accessibility — it's SEO too.
+
+---
+
+## Naming rules
+
+- Home page section: **Featured Work**. About page section: **Some Of My Projects**. Do not rename either to match the other; they intentionally show different content (home = 2 highlights, about = full 6).
+- The book is **Your Authentic Signature** (title) with subtitle **A Personal Branding Handbook**.
+- The program is **Brand Experience** (Elegance Inspired's initiative), delivered via **Brand Xperience** (the learning platform). Both spellings are correct; do not "fix" the missing E in Xperience.
+
+---
+
+## Process rules
+
+- Break work into ~5 issues per PR. Three merged PRs shipped Branch A cleanly at that grain.
+- Each PR must run `npx tsc --noEmit` clean before merge.
+- Each PR body must list `Closes #<n>` for every issue it resolves, so GitHub auto-closes them.
+- Squash-merge PRs into `main` (default in this repo).
+- If a PR conflicts because another PR merged first, rebase on `origin/main`, resolve, and force-push with `--force-with-lease`. Do not merge `main` back into a feature branch.
+
+---
+
+## When something on this list feels wrong
+
+Update this file in the same PR as the change. Rules that live only in someone's head become the next audit finding.


### PR DESCRIPTION
## Summary

Four reference docs so future work on this repo doesn't re-derive what we already know.

- **CLAUDE.md** — project context: purpose, tech stack, directory map, brand tokens, env vars, branch strategy, roadmap. First-read for any new session.
- **RULES.md** — decisions made because of specific past mistakes on this site: AI-flavoured copy to avoid, fact-check requirements, image / component / brand / SEO / naming / process rules.
- **AUDIT.md** — the full four-lens audit (SE / UI-UX / Copy / CMO), missing sections, overdone patterns, corrections to public facts about Temitope, and a Branch A ship log with issue numbers.
- **REDESIGN.md** — the Branch B plan: new IA (8 pages), palette migration to cream + rose (hot pink as equity only), typography reduction to 2 families, per-page specs, suggested PR sequencing, reference sites, an explicit "not doing" list.

Everything is sourced from public material only (her site, LinkedIn, IG bio, TechEconomy Sept 2025, The Upper Ent Sept 2025, brandxperience.org, eleganceinspired.org). No fabricated biography, no invented awards.

## Test plan

- [ ] Files render on GitHub with correct markdown formatting.
- [ ] Cross-references between docs (`RULES.md` ↔ `AUDIT.md` ↔ `REDESIGN.md`) resolve.
- [ ] Nothing else in the repo changed (only 4 new top-level files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)