### PR TITLE
Redesign B1: palette + IA + stub pages (foundations)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,9 @@ Fonts (loaded in `layout.tsx`):
 | ------------------- | ----------- | --------------------------------- |
 | Avenir              | Local sans  | Default `font-sans` — most body   |
 | Averia Serif Libre  | Local serif | `font-serif` — display headlines  |
-| SK Modernist        | Local sans  | `font-sk-modernist` — /branding page only |
+| SK Modernist        | Local sans  | (dropped in Branch B — no longer loaded) |
 
-Poppins and Bai Jamjuree were removed in PR #33. Do not re-add fonts without justification.
+Poppins and Bai Jamjuree were removed in PR #33. SK Modernist was removed in the Branch B foundations PR. Averia is intentionally kept — we tried swapping it for Fraunces and reverted. Do not re-add fonts or swap the existing ones without an explicit ask.
 
 Redesign palette (Branch B — see `REDESIGN.md`):
 

--- a/REDESIGN.md
+++ b/REDESIGN.md
@@ -73,14 +73,16 @@ All text/background combinations must pass WCAG AA. White on `#FFD1F7` (the curr
 
 ## Typography
 
-From 3 families down to 2:
+From 3 families down to 2. **Fonts stay as they are today** — the "texture" of the site is part of what's being kept:
 
-- **Display serif:** Fraunces (variable, warm, character-rich) or Cormorant Garamond.
-- **Body sans:** Inter, or keep Avenir if the local font license is confirmed.
+- **Display serif:** Averia Serif Libre (kept).
+- **Body sans:** Avenir (kept).
 
-Drop: Averia, SK Modernist.
+Drop: SK Modernist (only used on `/branding`, which is being refactored to `/programs`).
 
 Type scale defined in `tailwind.config.ts` fontSize extension. Use `font-serif` for display + eyebrow labels only; `font-sans` for everything else.
+
+An earlier draft of this doc proposed swapping to Fraunces — that was rejected in review. Do not reintroduce a font change without an explicit ask.
 
 ---
 

--- a/src/app/books/layout.tsx
+++ b/src/app/books/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Books | Temitope Ruth Jacob",
+  description:
+    "Books and handbooks by Temitope Ruth Jacob, including Your Authentic Signature — A Personal Branding Handbook.",
+  alternates: { canonical: "https://www.temitoperuthjacob.com/books" },
+  openGraph: {
+    title: "Books | Temitope Ruth Jacob",
+    description:
+      "Books and handbooks by Temitope Ruth Jacob, including Your Authentic Signature.",
+    url: "https://www.temitoperuthjacob.com/books",
+    type: "website",
+    siteName: "Temitope Ruth Jacob",
+    images: [
+      {
+        url: "https://www.temitoperuthjacob.com/handbook.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Your Authentic Signature — Personal Branding Handbook",
+      },
+    ],
+  },
+};
+
+export default function BooksLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,0 +1,41 @@
+import Navbar from "@/components/navbar";
+import Footer from "@/components/footer";
+import ComingSoon from "@/components/coming-soon";
+
+export default function BooksPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <ComingSoon
+        kicker="Books"
+        title="Your Authentic Signature."
+        intro={
+          <>
+            <p>
+              A personal branding handbook &mdash; a guide to discovering,
+              defining and communicating your unique brand.
+            </p>
+            <p className="text-sm text-ink/50">
+              The dedicated book page (synopsis, table of contents, sample
+              chapter, endorsements) is being built. The handbook itself is
+              already available.
+            </p>
+          </>
+        }
+        ctas={[
+          {
+            href: "https://selar.com/1v4g42",
+            label: "Download the handbook",
+            external: true,
+          },
+          {
+            href: "/about",
+            label: "About the author",
+            variant: "outline",
+          },
+        ]}
+      />
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/branding/page.tsx
+++ b/src/app/branding/page.tsx
@@ -112,7 +112,7 @@ export default function BrandingInitiative() {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-pink-50 font-sk-modernist">
+    <div className="min-h-screen bg-cream font-sans">
       <Navbar/>
       {/* Hero Section */}
       <section className="relative overflow-hidden py-6 sm:py-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact | Temitope Ruth Jacob",
+  description:
+    "Reach out to Temitope Ruth Jacob for speaking, consulting, media or general enquiries.",
+  alternates: { canonical: "https://www.temitoperuthjacob.com/contact" },
+  openGraph: {
+    title: "Contact | Temitope Ruth Jacob",
+    description:
+      "Reach out for speaking, consulting, media or general enquiries.",
+    url: "https://www.temitoperuthjacob.com/contact",
+    type: "website",
+    siteName: "Temitope Ruth Jacob",
+    images: [
+      {
+        url: "https://www.temitoperuthjacob.com/pfp.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Contact Temitope Ruth Jacob",
+      },
+    ],
+  },
+};
+
+export default function ContactLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,91 @@
+import Navbar from "@/components/navbar";
+import Footer from "@/components/footer";
+import ComingSoon from "@/components/coming-soon";
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <ComingSoon
+        kicker="Contact"
+        title="Let's talk."
+        intro={
+          <>
+            <p>
+              A routed contact form (Speak &middot; Consult &middot; Media
+              &middot; Other) is on its way. Until then, the fastest ways to
+              reach Temitope are below.
+            </p>
+          </>
+        }
+        ctas={[
+          {
+            href: "mailto:hi@temitoperuthjacob.com",
+            label: "Email hi@temitoperuthjacob.com",
+          },
+          {
+            href: "https://wa.link/dtys70",
+            label: "WhatsApp",
+            external: true,
+            variant: "outline",
+          },
+        ]}
+      >
+        <dl className="border-t border-ink/10 pt-8 grid gap-6 sm:grid-cols-2 text-sm font-sans">
+          <div>
+            <dt className="text-ink/50 uppercase tracking-widest text-xs mb-2">
+              Email
+            </dt>
+            <dd className="text-ink">hi@temitoperuthjacob.com</dd>
+          </div>
+          <div>
+            <dt className="text-ink/50 uppercase tracking-widest text-xs mb-2">
+              Phone
+            </dt>
+            <dd className="text-ink">+(234) 904 404 4138</dd>
+          </div>
+          <div>
+            <dt className="text-ink/50 uppercase tracking-widest text-xs mb-2">
+              Based in
+            </dt>
+            <dd className="text-ink">Abuja, Nigeria</dd>
+          </div>
+          <div>
+            <dt className="text-ink/50 uppercase tracking-widest text-xs mb-2">
+              On the web
+            </dt>
+            <dd className="text-ink">
+              <a
+                href="https://ng.linkedin.com/in/temitoperuthjacob"
+                target="_blank"
+                rel="noreferrer"
+                className="text-rose hover:underline"
+              >
+                LinkedIn
+              </a>{" "}
+              &middot;{" "}
+              <a
+                href="https://www.instagram.com/brandingqueen2"
+                target="_blank"
+                rel="noreferrer"
+                className="text-rose hover:underline"
+              >
+                Instagram
+              </a>{" "}
+              &middot;{" "}
+              <a
+                href="https://x.com/thebrand_queen"
+                target="_blank"
+                rel="noreferrer"
+                className="text-rose hover:underline"
+              >
+                X
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </ComingSoon>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,14 @@
 :root {
   --primary: 102, 37, 103;
   --secondary: 156, 39, 176;
+
+  /* Redesign palette — see REDESIGN.md */
+  --brand-pink: 255, 0, 102;   /* #F06 — logo + one hero highlight only */
+  --cream: 250, 246, 241;      /* #FAF6F1 — page background */
+  --ink: 26, 22, 20;           /* #1A1614 — body text */
+  --rose: 212, 117, 107;       /* #D4756B — interactive accent */
+  --blush: 244, 221, 213;      /* #F4DDD5 — surface tint */
+  --aubergine: 61, 31, 46;     /* #3D1F2E — footer + dark panels */
 }
 
 .text-primary-dark {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,23 +43,6 @@ const averia = localFont({
   fallback: ["serif"],
 });
 
-const skModernist = localFont({
-  src: [
-    {
-      path: "../../public/fonts/sk/Sk-Modernist-Regular.otf",
-      weight: "400",
-      style: "normal",
-    },
-    {
-      path: "../../public/fonts/sk/Sk-Modernist-Bold.otf",
-      weight: "700",
-      style: "normal",
-    },
-  ],
-  variable: "--font-sk-modernist",
-  fallback: ["system-ui", "sans-serif"],
-});
-
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.temitoperuthjacob.com"),
   title: "Temitope Ruth Jacob | Brand Strategist, Speaker, Author",
@@ -123,7 +106,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${avenir.variable} ${averia.variable} ${skModernist.variable} font-sans`}
+        className={`${avenir.variable} ${averia.variable} font-sans bg-cream text-ink`}
       >
         <Analytics />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,7 +90,7 @@ export default function HomePage() {
       >
         <main className="overflow-hidden">
           <motion.section
-            className="bg-gray-200"
+            className="bg-cream"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.8 }}

--- a/src/app/programs/layout.tsx
+++ b/src/app/programs/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Programs | Temitope Ruth Jacob",
+  description:
+    "Personal branding programs from Brand Xperience: SPROUT, BrandUp, Resonance Blueprint, Own Your Name, and The Influence Code.",
+  alternates: { canonical: "https://www.temitoperuthjacob.com/programs" },
+  openGraph: {
+    title: "Programs | Temitope Ruth Jacob",
+    description:
+      "Personal branding programs from Brand Xperience for professionals and organisations.",
+    url: "https://www.temitoperuthjacob.com/programs",
+    type: "website",
+    siteName: "Temitope Ruth Jacob",
+    images: [
+      {
+        url: "https://www.temitoperuthjacob.com/pfp.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Brand Xperience programs",
+      },
+    ],
+  },
+};
+
+export default function ProgramsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,0 +1,40 @@
+import Navbar from "@/components/navbar";
+import Footer from "@/components/footer";
+import ComingSoon from "@/components/coming-soon";
+
+export default function ProgramsPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <ComingSoon
+        kicker="Programs"
+        title="Programs from Brand Xperience."
+        intro={
+          <>
+            <p>
+              Five named programs are being consolidated here: <strong>SPROUT</strong>{" "}
+              (a personal branding conversation), <strong>BrandUp</strong> (a
+              personal branding course), <strong>Resonance Blueprint</strong> (a
+              strategy masterclass), <strong>Own Your Name</strong> (a university
+              tour), and <strong>The Influence Code</strong> (a conference).
+            </p>
+            <p className="text-sm text-ink/50">
+              While the full hub is being built, the current Brand Experience
+              Initiative page is still available.
+            </p>
+          </>
+        }
+        ctas={[
+          { href: "/branding", label: "Current Brand Experience page" },
+          {
+            href: "https://www.brandxperience.org",
+            label: "Visit Brand Xperience",
+            external: true,
+            variant: "outline",
+          },
+        ]}
+      />
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/resources/layout.tsx
+++ b/src/app/resources/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Resources | Temitope Ruth Jacob",
+  description:
+    "Free tools, articles, videos and downloads to help you build your personal brand.",
+  alternates: { canonical: "https://www.temitoperuthjacob.com/resources" },
+  openGraph: {
+    title: "Resources | Temitope Ruth Jacob",
+    description:
+      "Free tools, articles, videos and downloads to help you build your personal brand.",
+    url: "https://www.temitoperuthjacob.com/resources",
+    type: "website",
+    siteName: "Temitope Ruth Jacob",
+    images: [
+      {
+        url: "https://www.temitoperuthjacob.com/pfp.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Resources from Temitope Ruth Jacob",
+      },
+    ],
+  },
+};
+
+export default function ResourcesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,0 +1,39 @@
+import Navbar from "@/components/navbar";
+import Footer from "@/components/footer";
+import ComingSoon from "@/components/coming-soon";
+
+export default function ResourcesPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <ComingSoon
+        kicker="Resources"
+        title="Free tools to build your personal brand."
+        intro={
+          <>
+            <p>
+              A filterable library &mdash; free downloads, articles, podcast
+              episodes, videos, and community links &mdash; is being built. In
+              the meantime, the current selection is featured on the home page,
+              and the personal branding handbook is available to download.
+            </p>
+          </>
+        }
+        ctas={[
+          {
+            href: "https://selar.com/1v4g42",
+            label: "Download the handbook",
+            external: true,
+          },
+          {
+            href: "https://temitoperuthjacob.medium.com",
+            label: "Read the articles",
+            external: true,
+            variant: "outline",
+          },
+        ]}
+      />
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,7 +4,17 @@ const SITE_URL = "https://www.temitoperuthjacob.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
-  const routes = ["", "/about", "/branding", "/privacy"];
+  const routes = [
+    "",
+    "/about",
+    "/speaking",
+    "/books",
+    "/programs",
+    "/resources",
+    "/contact",
+    "/branding",
+    "/privacy",
+  ];
   return routes.map((path) => ({
     url: `${SITE_URL}${path}`,
     lastModified: now,

--- a/src/app/speaking/layout.tsx
+++ b/src/app/speaking/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Speaking | Temitope Ruth Jacob",
+  description:
+    "Book Temitope Ruth Jacob to speak on personal branding, African brand identity, and the shift from execution to influence.",
+  alternates: { canonical: "https://www.temitoperuthjacob.com/speaking" },
+  openGraph: {
+    title: "Speaking | Temitope Ruth Jacob",
+    description:
+      "Book Temitope Ruth Jacob to speak on personal branding, African brand identity, and the shift from execution to influence.",
+    url: "https://www.temitoperuthjacob.com/speaking",
+    type: "website",
+    siteName: "Temitope Ruth Jacob",
+    images: [
+      {
+        url: "https://www.temitoperuthjacob.com/pfp.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Temitope Ruth Jacob — Speaking",
+      },
+    ],
+  },
+};
+
+export default function SpeakingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/speaking/page.tsx
+++ b/src/app/speaking/page.tsx
@@ -1,0 +1,35 @@
+import Navbar from "@/components/navbar";
+import Footer from "@/components/footer";
+import ComingSoon from "@/components/coming-soon";
+
+export default function SpeakingPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <ComingSoon
+        kicker="Speaking"
+        title="Book Temitope to speak."
+        intro={
+          <>
+            <p>
+              Signature talks on personal branding, African brand identity, and
+              the shift from execution to influence. Past stages include
+              TEDxSamaru, NECCI PR Roundtable, PerformX Summit, the Upgrade
+              Marketing Conference, and MYFICON.
+            </p>
+            <p className="text-sm text-ink/50">
+              The full page &mdash; signature topics, reel, downloadable
+              one-sheet, and a booking form &mdash; is coming shortly. In the
+              meantime, reach out directly.
+            </p>
+          </>
+        }
+        ctas={[
+          { href: "/contact", label: "Enquire about speaking" },
+          { href: "/about", label: "About Temitope", variant: "outline" },
+        ]}
+      />
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/about/education.tsx
+++ b/src/components/about/education.tsx
@@ -26,15 +26,15 @@ function Education() {
   };
 
   return (
-    <section className="py-12 md:py-24 px-4 sm:px-10 bg-primary relative z-30">
+    <section className="py-12 md:py-24 px-4 sm:px-10 bg-aubergine relative z-30">
       <div
         className="absolute inset-0 bg-contain z-0"
         style={{
           backgroundImage: "url(/pattern.png)",
-          opacity: 0.1,
+          opacity: 0.08,
         }}
       />
-      <div className="container mx-auto relative !text-black z-10">
+      <div className="container mx-auto relative z-10">
         <motion.div
           className="flex justify-between items-center mb-12"
           initial={{ opacity: 0, y: -30 }}
@@ -42,7 +42,7 @@ function Education() {
           viewport={{ once: true }}
           transition={{ duration: 0.8, ease: "easeOut" }}
         >
-          <h2 className="font-serif text-3xl md:text-4xl capitalize text-white font-semibold">
+          <h2 className="font-serif text-3xl md:text-4xl capitalize text-cream font-semibold">
             Education and recent Certifications
           </h2>
         </motion.div>
@@ -57,33 +57,33 @@ function Education() {
             className="flex flex-col gap-6 lg:max-w-lg"
             variants={itemVariants}
           >
-            <h4 className="font-semibold text-3xl text-white font-serif">
+            <h4 className="font-semibold text-3xl text-cream font-serif">
               Recent Certifications
             </h4>
             <motion.hr
-              className="bg-white w-2/3"
+              className="bg-rose w-2/3"
               initial={{ width: 0 }}
               whileInView={{ width: "66.666667%" }}
               viewport={{ once: true }}
               transition={{ duration: 0.8, delay: 0.5 }}
             />
             <motion.div className="flex flex-col" variants={itemVariants}>
-              <p className="mb-2 text-xl text-white font-semibold font-serif">
+              <p className="mb-2 text-xl text-cream font-semibold font-serif">
                 London School of Business Administration: Brand Management
               </p>
-              <span className="text-lightGray/80 font-sans">-London, UK</span>
+              <span className="text-cream/70 font-sans">-London, UK</span>
             </motion.div>
             <motion.div className="flex flex-col" variants={itemVariants}>
-              <p className="mb-2 text-xl text-white font-semibold font-serif">
+              <p className="mb-2 text-xl text-cream font-semibold font-serif">
                 London School of Business Administration: Digital Marketing
               </p>
-              <span className="text-lightGray/80 font-sans">-London, UK</span>
+              <span className="text-cream/70 font-sans">-London, UK</span>
             </motion.div>
             <motion.div className="flex flex-col" variants={itemVariants}>
-              <p className="mb-2 text-xl text-white font-semibold font-serif">
+              <p className="mb-2 text-xl text-cream font-semibold font-serif">
                 Agillant Group: Agile/Scrum Project Management
               </p>
-              <span className="text-lightGray/80 font-sans">
+              <span className="text-cream/70 font-sans">
                 -North Carolina, USA
               </span>
             </motion.div>
@@ -92,28 +92,28 @@ function Education() {
             className="flex flex-col gap-6 lg:max-w-lg"
             variants={itemVariants}
           >
-            <h4 className="font-semibold text-3xl text-white font-serif">
+            <h4 className="font-semibold text-3xl text-cream font-serif">
               Education
             </h4>
             <motion.hr
-              className="bg-white w-1/3"
+              className="bg-rose w-1/3"
               initial={{ width: 0 }}
               whileInView={{ width: "33.333333%" }}
               viewport={{ once: true }}
               transition={{ duration: 0.8, delay: 0.7 }}
             />
             <motion.div className="flex flex-col" variants={itemVariants}>
-              <p className="mb-2 text-xl text-white font-semibold font-serif">
+              <p className="mb-2 text-xl text-cream font-semibold font-serif">
                 Rome Business School | MSc. Marketing And Sales
               </p>
-              <span className="text-lightGray/80 font-sans">-Rome, Italy</span>
+              <span className="text-cream/70 font-sans">-Rome, Italy</span>
             </motion.div>
             <motion.div className="flex flex-col" variants={itemVariants}>
-              <span className="text-lightGray/80"></span>
-              <p className="mb-2 text-xl text-white font-semibold font-serif">
+              <span className="text-cream/70"></span>
+              <p className="mb-2 text-xl text-cream font-semibold font-serif">
                 Ahmadu Bello University | BSc. Human Anatomy
               </p>
-              <span className="text-lightGray/80 font-sans">
+              <span className="text-cream/70 font-sans">
                 -Zaria, Nigeria
               </span>
             </motion.div>

--- a/src/components/about/projects.tsx
+++ b/src/components/about/projects.tsx
@@ -111,7 +111,7 @@ function RecentProjects() {
             whileHover={{ scale: 1.02, transition: { duration: 0.2 } }}
           >
             <motion.span
-              className="flex-shrink-0 w-10 h-12 flex items-center justify-center bg-primary text-white rounded font-sans"
+              className="flex-shrink-0 w-10 h-12 flex items-center justify-center bg-rose text-white rounded font-sans"
               whileHover={{ scale: 1.1 }}
               transition={{ duration: 0.2 }}
             >

--- a/src/components/about/skills-and-speaking.tsx
+++ b/src/components/about/skills-and-speaking.tsx
@@ -56,13 +56,13 @@ export default function SkillsAndSpeaking() {
     <div className="grid xl:grid-cols-2 mx-auto container xl:px-10">
       {/* Skills Section */}
       <motion.div
-        className="bg-primary p-8 md:p-12"
+        className="bg-aubergine p-8 md:p-12"
         initial={{ x: -100, opacity: 0 }}
         whileInView={{ x: 0, opacity: 1 }}
         viewport={{ once: true }}
         transition={{ duration: 0.8, ease: "easeOut" }}
       >
-        <h2 className="font-serif text-2xl md:text-3xl text-white mb-8">
+        <h2 className="font-serif text-2xl md:text-3xl text-cream mb-8">
           My Top Skills
         </h2>
         <motion.div
@@ -88,14 +88,14 @@ export default function SkillsAndSpeaking() {
 
       {/* Speaking Section */}
       <motion.div
-        className="bg-[#FFD1F7] p-8 md:p-12 flex flex-col justify-center"
+        className="bg-blush p-8 md:p-12 flex flex-col justify-center"
         initial={{ x: 100, opacity: 0 }}
         whileInView={{ x: 0, opacity: 1 }}
         viewport={{ once: true }}
         transition={{ duration: 0.8, ease: "easeOut" }}
       >
         <motion.h2
-          className="font-serif text-3xl md:text-4xl text-primary mb-8 leading-tight"
+          className="font-serif text-3xl md:text-4xl text-aubergine mb-8 leading-tight"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -109,12 +109,14 @@ export default function SkillsAndSpeaking() {
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.4 }}
         >
-          <Button
-            variant="primary"
-            className="inline-flex items-center bg-primary hover:bg-primary/90 transition-all duration-300 hover:scale-105 font-sans"
-          >
-            CONNECT WITH ME
-          </Button>
+          <a href="/speaking">
+            <Button
+              variant="primary"
+              className="inline-flex items-center bg-rose hover:bg-aubergine transition-all duration-300 hover:scale-105 font-sans"
+            >
+              BOOK TEMITOPE
+            </Button>
+          </a>
         </motion.div>
       </motion.div>
     </div>

--- a/src/components/achievements.tsx
+++ b/src/components/achievements.tsx
@@ -37,7 +37,7 @@ function Achievements({ setActivePage }: AchievementsProps) {
         transition={{ duration: 0.6 }}
         viewport={{ once: true }}
       >
-        <h2 className="font-averia font-semibold text-3xl md:text-4xl">
+        <h2 className="font-serif font-semibold text-3xl md:text-4xl">
           Featured Work
         </h2>
         <Button
@@ -45,7 +45,7 @@ function Achievements({ setActivePage }: AchievementsProps) {
           onClick={() => {
             window.location.href = "/about#projects";
           }}
-          className="font-avenir"
+          className="font-sans"
         >
           SEE ALL PROJECTS
         </Button>
@@ -62,29 +62,29 @@ function Achievements({ setActivePage }: AchievementsProps) {
             whileHover={{ scale: 1.02 }}
           >
             <motion.span
-              className="flex-shrink-0 w-10 h-12 flex items-center justify-center bg-primary text-white rounded font-avenir font-bold"
+              className="flex-shrink-0 w-10 h-12 flex items-center justify-center bg-rose text-white rounded font-sans font-bold"
               whileHover={{ scale: 1.1 }}
             >
               {index + 1}
             </motion.span>
             <div className="flex flex-col sm:flex-row gap-6 sm:gap-10">
               <div className="lg:max-w-[340px] text-center sm:text-start max-sm:border-b max-sm:pb-3">
-                <h3 className="font-averia font-semibold text-secondary text-xl mb-2">
+                <h3 className="font-serif font-semibold text-secondary text-xl mb-2">
                   {achievement.title}
                 </h3>
-                <p className="text-secondary-2 mb-2 text-sm font-semibold font-avenir">
+                <p className="text-secondary-2 mb-2 text-sm font-semibold font-sans">
                   {achievement.organization}
                 </p>
-                <p className="text-secondary-2 mb-2 text-sm font-avenir">
+                <p className="text-secondary-2 mb-2 text-sm font-sans">
                   {achievement.role}
                 </p>
               </div>
 
               <div className="flex flex-col items-center sm:items-start gap-3 sm:border-l-[1.5px] sm:pl-8 border-secondary-2">
-                <span className="uppercase tracking-wider font-avenir text-sm">
+                <span className="uppercase tracking-wider font-sans text-sm">
                   {achievement.location}
                 </span>
-                <span className="text-gray-500 pb-4 max-sm:border-b-[1.5px] max-sm:w-fit max-sm:px-10 font-avenir">
+                <span className="text-gray-500 pb-4 max-sm:border-b-[1.5px] max-sm:w-fit max-sm:px-10 font-sans">
                   {achievement.year}
                 </span>
               </div>

--- a/src/components/coming-soon.tsx
+++ b/src/components/coming-soon.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+interface CtaProps {
+  href: string;
+  label: string;
+  external?: boolean;
+  variant?: "primary" | "outline";
+}
+
+interface ComingSoonProps {
+  kicker: string;
+  title: string;
+  intro: ReactNode;
+  ctas?: CtaProps[];
+  children?: ReactNode;
+}
+
+export default function ComingSoon({
+  kicker,
+  title,
+  intro,
+  ctas,
+  children,
+}: ComingSoonProps) {
+  return (
+    <main className="container mx-auto px-4 sm:px-10 py-16 xl:py-24 max-w-3xl">
+      <p className="text-xs font-medium tracking-[0.2em] uppercase text-rose font-sans mb-4">
+        {kicker}
+      </p>
+      <h1 className="font-serif text-4xl md:text-5xl xl:text-6xl text-ink font-semibold leading-tight mb-6">
+        {title}
+      </h1>
+      <div className="text-base sm:text-lg text-ink/70 font-sans leading-relaxed mb-8 space-y-4">
+        {typeof intro === "string" ? <p>{intro}</p> : intro}
+      </div>
+      {ctas && ctas.length > 0 && (
+        <div className="flex flex-wrap gap-4">
+          {ctas.map((cta) => {
+            const isPrimary = cta.variant !== "outline";
+            const className = isPrimary
+              ? "inline-flex items-center justify-center uppercase tracking-widest text-xs sm:text-sm bg-rose text-white font-sans font-medium px-5 py-3 rounded-tl-3xl hover:bg-aubergine transition-colors"
+              : "inline-flex items-center justify-center uppercase tracking-widest text-xs sm:text-sm bg-blush text-ink font-sans font-medium px-5 py-3 rounded-br-3xl hover:bg-rose hover:text-white transition-colors";
+            return cta.external ? (
+              <a
+                key={cta.href}
+                href={cta.href}
+                target="_blank"
+                rel="noreferrer"
+                className={className}
+              >
+                {cta.label}
+              </a>
+            ) : (
+              <Link key={cta.href} href={cta.href} className={className}>
+                {cta.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+      {children && <div className="mt-12">{children}</div>}
+    </main>
+  );
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -43,7 +43,7 @@ const Footer = () => {
   };
 
   return (
-    <footer className="bg-zinc-800 text-white/80 py-12 xl:py-24 px-4 lg:px-10">
+    <footer className="bg-aubergine text-cream/80 py-12 xl:py-24 px-4 lg:px-10">
       <div className="container mx-auto">
         <motion.div
           className="mb-12 flex flex-col"
@@ -52,25 +52,25 @@ const Footer = () => {
           transition={{ duration: 0.6 }}
           viewport={{ once: true }}
         >
-          <p className="text-white/70 uppercase tracking-widest flex items-center justify-center xl:justify-start gap-2 mb-4 font-sans">
-            Have a Project ? Get in Touch
+          <p className="text-cream/70 uppercase tracking-widest flex items-center justify-center xl:justify-start gap-2 mb-4 font-sans">
+            Have a project? Get in touch.
           </p>
           <div className="flex flex-col xl:flex-row justify-between items-end md:items-center gap-4">
-            <h2 className="font-serif text-xl sm:text-3xl font-semibold md:text-4xl text-white">
+            <h2 className="font-serif text-xl sm:text-3xl font-semibold md:text-4xl text-cream">
               hi@temitoperuthjacob.com
             </h2>
-            <a href="https://selar.com/412292" target="_blank" rel="noreferrer">
+            <Link href="/contact">
               <Button
                 variant="primary"
-                className="bg-primary rounded-br-2xl duration-300 hover:bg-white hover:text-primary border border-primary text-white px-6 py-2 font-sans transition-colors"
+                className="bg-rose rounded-br-2xl duration-300 hover:bg-cream hover:text-aubergine border border-rose text-white px-6 py-2 font-sans transition-colors"
               >
-                MEET TEMITOPE
+                CONTACT TEMITOPE
               </Button>
-            </a>
+            </Link>
           </div>
         </motion.div>
 
-        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-8 py-12 border-t border-white/10">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-8 py-12 border-t border-cream/10">
           <motion.div
             initial={{ opacity: 0, x: -30 }}
             whileInView={{ opacity: 1, x: 0 }}
@@ -84,9 +84,9 @@ const Footer = () => {
               height={40}
               className="mb-4"
             />
-            <p className="text-sm text-white/60 font-sans">
-              Personal Branding | Marketing | Communication | Advertising |
-              Strategy
+            <p className="text-sm text-cream/60 font-sans">
+              Brand strategy, storytelling and speaking for founders,
+              executives and purpose-led organisations across Africa.
             </p>
           </motion.div>
 
@@ -96,8 +96,8 @@ const Footer = () => {
             transition={{ duration: 0.5, delay: 0.1 }}
             viewport={{ once: true }}
           >
-            <h3 className="font-serif text-lg mb-4">Contact Details</h3>
-            <div className="space-y-2 text-white/60 font-sans">
+            <h3 className="font-serif text-lg mb-4 text-cream">Contact Details</h3>
+            <div className="space-y-2 text-cream/60 font-sans">
               <p>Abuja, Nigeria</p>
               <p>hi@temitoperuthjacob.com</p>
               <p>+(234) 9044044138</p>
@@ -110,7 +110,7 @@ const Footer = () => {
             transition={{ duration: 0.5, delay: 0.2 }}
             viewport={{ once: true }}
           >
-            <h3 className="font-serif text-lg mb-4">Follow Me</h3>
+            <h3 className="font-serif text-lg mb-4 text-cream">Follow Me</h3>
             <div className="flex gap-4 sm:gap-6">
               {[
                 {
@@ -166,28 +166,30 @@ const Footer = () => {
             viewport={{ once: true }}
           >
             <div>
-              <p className="text-lg font-semibold font-serif">Work With Me</p>
+              <p className="text-lg font-semibold font-serif text-cream">
+                Work With Me
+              </p>
             </div>
             <form
               onSubmit={handleSubscribe}
               noValidate
               className="flex flex-col gap-2"
             >
-              <div className="bg-accent rounded-lg flex items-center gap-2 py-1.5 px-2.5">
+              <div className="bg-cream/10 rounded-lg flex items-center gap-2 py-1.5 px-2.5">
                 <input
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
                   disabled={status === "loading"}
-                  className="bg-accent rounded-lg placeholder:text-secondary/50 py-1 text-secondary w-full focus:outline-none px-2 font-sans disabled:opacity-60"
+                  className="bg-transparent rounded-lg placeholder:text-cream/40 py-1 text-cream w-full focus:outline-none px-2 font-sans disabled:opacity-60"
                   placeholder="Enter your email address"
                   aria-label="Email address"
                 />
                 <button
                   type="submit"
                   disabled={status === "loading" || !email}
-                  className="flex items-center gap-2 justify-center uppercase font-sans font-medium focus-visible:outline-none bg-primary text-white px-4 py-1.5 rounded-lg transition-all duration-300 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex items-center gap-2 justify-center uppercase font-sans font-medium focus-visible:outline-none bg-rose text-white px-4 py-1.5 rounded-lg transition-all duration-300 hover:bg-cream hover:text-aubergine disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {status === "loading" ? "Sending..." : "Subscribe"}
                 </button>
@@ -196,9 +198,7 @@ const Footer = () => {
                 <p
                   role={status === "error" ? "alert" : "status"}
                   className={`text-xs font-sans ${
-                    status === "error"
-                      ? "text-red-300"
-                      : "text-white/80"
+                    status === "error" ? "text-red-300" : "text-cream/80"
                   }`}
                 >
                   {message}
@@ -209,7 +209,7 @@ const Footer = () => {
         </div>
 
         <motion.div
-          className="flex flex-col md:flex-row justify-between items-center gap-4 pt-6 sm:pt-12 border-t border-white/10 text-sm text-white/40"
+          className="flex flex-col md:flex-row justify-between items-center gap-4 pt-6 sm:pt-12 border-t border-cream/10 text-sm text-cream/40"
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           transition={{ duration: 0.5, delay: 0.4 }}
@@ -220,22 +220,22 @@ const Footer = () => {
             Designed By <br className="hidden xl:block" />
             <Link
               href="https://nwanne-san.vercel.app"
-              className="text-primary hover:text-primary/80"
+              className="text-rose hover:text-rose/80"
             >
               Nwanne Nnamani.
             </Link>
-            <span className="text-white px-2">|</span>
+            <span className="text-cream/60 px-2">|</span>
             <Link
               href="https://eleganceinspired.org"
               target="_blank"
-              className="text-primary hover:text-primary/80"
+              className="text-rose hover:text-rose/80"
             >
               Elegance Inspired Limited
             </Link>
           </p>
           <Link
             href="/privacy"
-            className="hover:text-white/60 sm:block hidden font-sans"
+            className="hover:text-cream/80 sm:block hidden font-sans"
           >
             Privacy Policy
           </Link>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -52,17 +52,17 @@ function Hero() {
         animate="visible"
       >
         <motion.div variants={itemVariants}>
-          <p className="hidden sm:block text-xs sm:text-sm font-medium tracking-[0.2em] uppercase text-primary font-sans">
+          <p className="hidden sm:block text-xs sm:text-sm font-medium tracking-[0.2em] uppercase text-rose font-sans">
             Brand Strategist &middot; Speaker &middot; Author
           </p>
         </motion.div>
 
         <motion.h1
-          className="text-3xl sm:text-4xl xl:text-5xl leading-tight font-semibold font-serif text-secondary"
+          className="text-3xl sm:text-4xl xl:text-5xl leading-tight font-semibold font-serif text-ink"
           variants={itemVariants}
         >
           I shape how African brands{" "}
-          <span className="text-primary">show up, grow and succeed.</span>
+          <span className="text-brand-pink">show up, grow and succeed.</span>
         </motion.h1>
 
         <motion.p
@@ -77,37 +77,37 @@ function Hero() {
           className="flex gap-6 lg:justify-between xl:justify-normal lg:gap-40 xl:gap-4 font-serif"
           variants={itemVariants}
         >
-          <a href="https://selar.com/412292" target="_blank" rel="noreferrer">
+          <Link href="/speaking">
             <Button
               variant="primary"
-              className="bg-primary text-white text-nowrap tracking-widest py-3 px-5 rounded-tl-3xl text-xs sm:text-sm duration-300 hover:bg-primary/10 hover:text-primary border hover:scale-105 transition-all"
+              className="bg-rose text-white text-nowrap tracking-widest py-3 px-5 rounded-tl-3xl text-xs sm:text-sm duration-300 hover:bg-aubergine hover:text-white border-0 hover:scale-105 transition-all"
             >
-              MEET TEMITOPE
+              BOOK TEMITOPE TO SPEAK
             </Button>
-          </a>
+          </Link>
 
           <Button
             variant="outline"
-            className="border-0 text-secondary text-nowrap text-xs sm:text-sm tracking-widest duration-300 bg-lightGray rounded-br-3xl hover:scale-105 transition-all"
+            className="border-0 text-ink text-nowrap text-xs sm:text-sm tracking-widest duration-300 bg-blush rounded-br-3xl hover:scale-105 hover:bg-rose hover:text-white transition-all"
             onClick={() => {
-              window.location.href = "/about";
+              window.location.href = "/books";
             }}
           >
-            LEARN MORE
+            READ THE HANDBOOK
           </Button>
         </motion.div>
 
         <motion.div
-          className="flex flex-col sm:flex-row gap-2 pb-4 items-center text-black"
+          className="flex flex-col sm:flex-row gap-2 pb-4 items-center text-ink"
           variants={itemVariants}
         >
           <div className="flex gap-4 pt-4">
-            <p className="text-secondary font-medium capitalize font-sans">
+            <p className="text-ink font-medium capitalize font-sans">
               Connect with me
             </p>
           </div>
           <span className="flex items-center">
-            <hr className="text-secondary bg-secondary h-0.5 w-20 mt-3" />
+            <hr className="text-ink bg-ink/60 h-0.5 w-20 mt-3" />
           </span>
           <motion.div
             className="flex gap-3 pt-4 items-center"
@@ -144,7 +144,7 @@ function Hero() {
               <motion.div key={index} variants={socialVariants}>
                 <Link
                   href={social.href}
-                  className="text-secondary px-1 hover:scale-110 duration-300 bg-blck/0 rounded-full hover:text-primary transition-all hover:bg-rimary"
+                  className="text-ink px-1 hover:scale-110 duration-300 rounded-full hover:text-rose transition-all"
                   target="_blank"
                 >
                   <social.icon size={18} />
@@ -162,7 +162,7 @@ function Hero() {
         transition={{ duration: 1, ease: "easeOut" }}
       >
         <p className="text-center sm:hidden mb-2 my-5 leading-relaxed font-sans">
-          <span className="block text-xs font-medium tracking-[0.2em] uppercase text-primary mb-2">
+          <span className="block text-xs font-medium tracking-[0.2em] uppercase text-rose mb-2">
             Brand Strategist &middot; Speaker &middot; Author
           </span>
         </p>

--- a/src/components/logo-carousel.tsx
+++ b/src/components/logo-carousel.tsx
@@ -45,8 +45,8 @@ export default function LogoCarousel() {
   }, [isMounted]);
 
   return (
-    <section className="bg-primary flex flex-col md:flex-row gap-4 sm:gap-12 items-center py-6 sm:py-12 px-4 lg:px-10 -mt-16 sm:-mt-20 sm:z-20 relative">
-      <h2 className="font-serif text-2xl text-white mb-2 md:mb-0 px-4 font-semibold">
+    <section className="bg-aubergine flex flex-col md:flex-row gap-4 sm:gap-12 items-center py-6 sm:py-12 px-4 lg:px-10 -mt-16 sm:-mt-20 sm:z-20 relative">
+      <h2 className="font-serif text-2xl text-cream mb-2 md:mb-0 px-4 font-semibold">
         Organisations Impacted
       </h2>
       <div className="sm:px-7 overflow-hidden w-full">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import { Menu, X } from "lucide-react";
 import { Button } from "./ui/button";
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -61,10 +61,9 @@ const menuItemVariants = {
   },
 };
 
-export default function Navbar({ activePage, setActivePage }: NavbarProps) {
+export default function Navbar({}: NavbarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
-  const router = useRouter();
 
   const [isBrandXDomain, setIsBrandXDomain] = useState(false);
 
@@ -78,44 +77,12 @@ export default function Navbar({ activePage, setActivePage }: NavbarProps) {
     }
   }, []);
 
-  const scrollToSection = (sectionId: string) => {
-    setIsOpen(false);
-
-    if (pathname !== "/") {
-      router.push("/");
-      setTimeout(() => {
-        const section = document.getElementById(sectionId);
-        if (section) {
-          section.scrollIntoView({ behavior: "smooth" });
-        }
-      }, 100);
-      return;
-    }
-
-    const section = document.getElementById(sectionId);
-    if (section) {
-      section.scrollIntoView({ behavior: "smooth" });
-    }
-  };
-
   const isActivePath = (path: string) => {
     if (path === "/") {
       return pathname === "/";
     }
     return pathname.startsWith(path);
   };
-
-  useEffect(() => {
-    if (pathname === "/" && window.location.hash) {
-      const sectionId = window.location.hash.substring(1);
-      const section = document.getElementById(sectionId);
-      if (section) {
-        setTimeout(() => {
-          section.scrollIntoView({ behavior: "smooth" });
-        }, 500);
-      }
-    }
-  }, [pathname]);
 
   useEffect(() => {
     if (isOpen) {
@@ -133,8 +100,16 @@ export default function Navbar({ activePage, setActivePage }: NavbarProps) {
     return null;
   }
 
+  const navItems = [
+    { label: "About", href: "/about" },
+    { label: "Speaking", href: "/speaking" },
+    { label: "Books", href: "/books" },
+    { label: "Programs", href: "/programs" },
+    { label: "Resources", href: "/resources" },
+  ];
+
   return (
-    <div className="bg-gray-200">
+    <div className="bg-cream">
       <motion.nav
         className="mx-auto container relative px-4 py-6 sm:px-10 flex justify-between items-center font-sans"
         initial={{ opacity: 0, y: -20 }}
@@ -156,73 +131,37 @@ export default function Navbar({ activePage, setActivePage }: NavbarProps) {
         </Link>
 
         {/* Desktop Menu */}
-        <div className="hidden text-sm xl:flex items-center gap-8 font-serif">
-          <Link
-            href="/"
-            className={`transition-all duration-300 relative hover:scale-105 ${
-              isActivePath("/")
-                ? "text-primary font-medium"
-                : "hover:text-primary"
-            }`}
-          >
-            HOME
-            {isActivePath("/") && (
-              <motion.span
-                className="absolute -bottom-2 left-0 w-full h-0.5 bg-primary"
-                layoutId="activeTab"
-                transition={{ type: "spring", stiffness: 380, damping: 30 }}
-              />
-            )}
-          </Link>
-          <Link
-            href="/about"
-            className={`transition-all duration-300 relative hover:scale-105 ${
-              isActivePath("/about")
-                ? "text-primary font-medium"
-                : "hover:text-primary"
-            }`}
-          >
-            ABOUT TEMITOPE
-            {isActivePath("/about") && (
-              <motion.span
-                className="absolute -bottom-2 left-0 w-full h-0.5 bg-primary"
-                layoutId="activeTab"
-                transition={{ type: "spring", stiffness: 380, damping: 30 }}
-              />
-            )}
-          </Link>
-          <a
-            href="https://brandxperience.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="transition-all duration-300 relative hover:scale-105 hover:text-primary"
-          >
-            BRANDX
-          </a>
-          <motion.button
-            onClick={() => {
-              if (pathname !== "/") {
-                router.push("/#resources");
-              } else {
-                scrollToSection("resources");
-              }
-            }}
-            className="hover:text-primary transition-all duration-300 cursor-pointer hover:scale-105"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            RESOURCES
-          </motion.button>
+        <div className="hidden text-sm xl:flex items-center gap-8 font-serif uppercase tracking-wide">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`transition-all duration-300 relative hover:scale-105 ${
+                isActivePath(item.href)
+                  ? "text-rose font-medium"
+                  : "text-ink hover:text-rose"
+              }`}
+            >
+              {item.label}
+              {isActivePath(item.href) && (
+                <motion.span
+                  className="absolute -bottom-2 left-0 w-full h-0.5 bg-rose"
+                  layoutId="activeTab"
+                  transition={{ type: "spring", stiffness: 380, damping: 30 }}
+                />
+              )}
+            </Link>
+          ))}
         </div>
 
         <div className="flex items-center gap-3">
-          <a href="https://wa.link/dtys70" target="_blank" rel="noreferrer">
+          <Link href="/contact">
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-              <Button className="duration-300 px-3 text-xs py-1 sm:text-base hover:bg-white rounded-br-2xl hover:text-primary border border-primary font-sans">
-                Connect With Me
+              <Button className="duration-300 px-3 text-xs py-1 sm:text-base bg-rose text-white hover:bg-aubergine rounded-br-2xl border-0 font-sans">
+                Contact
               </Button>
             </motion.div>
-          </a>
+          </Link>
 
           <motion.button
             className="xl:hidden z-10"
@@ -293,7 +232,7 @@ export default function Navbar({ activePage, setActivePage }: NavbarProps) {
               </div>
 
               <motion.div
-                className="flex flex-col gap-6 mt-6 font-serif"
+                className="flex flex-col gap-6 mt-6 font-serif uppercase tracking-wide"
                 initial="closed"
                 animate="open"
                 variants={{
@@ -302,66 +241,36 @@ export default function Navbar({ activePage, setActivePage }: NavbarProps) {
                   },
                 }}
               >
+                {navItems.map((item) => (
+                  <motion.div key={item.href} variants={menuItemVariants}>
+                    <Link
+                      href={item.href}
+                      className={`transition-colors text-start relative pl-2 block ${
+                        isActivePath(item.href)
+                          ? "text-rose font-medium"
+                          : "text-ink hover:text-rose"
+                      }`}
+                      onClick={() => setIsOpen(false)}
+                    >
+                      {item.label}
+                      {isActivePath(item.href) && (
+                        <span className="absolute -bottom-2 left-0 w-fit h-0.5 bg-rose"></span>
+                      )}
+                    </Link>
+                  </motion.div>
+                ))}
                 <motion.div variants={menuItemVariants}>
                   <Link
-                    href="/"
+                    href="/contact"
+                    onClick={() => setIsOpen(false)}
                     className={`transition-colors text-start relative pl-2 block ${
-                      isActivePath("/")
-                        ? "text-primary font-medium"
-                        : "hover:text-primary"
+                      isActivePath("/contact")
+                        ? "text-rose font-medium"
+                        : "text-ink hover:text-rose"
                     }`}
-                    onClick={() => setIsOpen(false)}
                   >
-                    HOME
-                    {isActivePath("/") && (
-                      <span className="absolute -bottom-2 left-0 w-fit h-0.5 bg-primary"></span>
-                    )}
+                    Contact
                   </Link>
-                </motion.div>
-
-                <motion.div variants={menuItemVariants}>
-                  <Link
-                    href="/about"
-                    className={`transition-colors text-start relative pl-2 block ${
-                      isActivePath("/about")
-                        ? "text-primary font-medium"
-                        : "hover:text-primary"
-                    }`}
-                    onClick={() => setIsOpen(false)}
-                  >
-                    ABOUT TEMITOPE
-                    {isActivePath("/about") && (
-                      <span className="absolute -bottom-2 left-0 w-fit h-0.5 bg-primary"></span>
-                    )}
-                  </Link>
-                </motion.div>
-
-                <motion.div variants={menuItemVariants}>
-                  <a
-                    href="https://brandxperience.org"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="hover:text-primary transition-colors text-left cursor-pointer pl-2 block"
-                    onClick={() => setIsOpen(false)}
-                  >
-                    BRANDX
-                  </a>
-                </motion.div>
-
-                <motion.div variants={menuItemVariants}>
-                  <button
-                    onClick={() => {
-                      if (pathname !== "/") {
-                        router.push("/#resources");
-                      } else {
-                        scrollToSection("resources");
-                      }
-                      setIsOpen(false);
-                    }}
-                    className="hover:text-primary transition-colors text-left cursor-pointer pl-2 block"
-                  >
-                    RESOURCES
-                  </button>
                 </motion.div>
               </motion.div>
             </motion.div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,6 +25,14 @@ const config: Config = {
         secondary: "#4c4c4c",
         "secondary-2": "#797979",
         lightGray: "#FFD1F7",
+
+        // Redesign palette — see REDESIGN.md
+        "brand-pink": "#FF0066",
+        cream: "#FAF6F1",
+        ink: "#1A1614",
+        rose: "#D4756B",
+        blush: "#F4DDD5",
+        aubergine: "#3D1F2E",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {
@@ -69,9 +77,8 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ["var(--font-avenir)", "sans-serif"],
-        serif: ["var(--font-averia)", "serif"],
-        "sk-modernist": ["var(--font-sk-modernist)", "sans-serif"],
+        sans: ["var(--font-avenir)", "system-ui", "sans-serif"],
+        serif: ["var(--font-averia)", "Georgia", "serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary

First Branch B PR. Lays the foundation for the redesign — palette, information architecture, and stub pages for the six new routes — without doing the page-level content rewrites yet. Every subsequent redesign PR builds on this.

## Closes

- Closes #19 — Introduce new palette: cream + rose accent, hot pink for logo only
- Closes #20 — Consolidate typography to two families (serif display + sans body)
- Closes #21 — Update main navigation to new IA

## What changed

### Palette
- Added tokens to `tailwind.config.ts` + `globals.css`: `cream #FAF6F1`, `ink #1A1614`, `rose #D4756B`, `blush #F4DDD5`, `aubergine #3D1F2E`, `brand-pink #FF0066`. Existing `primary #F06` kept for backwards compat.
- Migrated section fills throughout the site:
  - **Hero wrapper**: `bg-gray-200` → `bg-cream`
  - **Testimonials**: hot-pink block → soft `bg-blush` with rose accents, quote glyph in rose, text ink
  - **Education**: hot-pink block → dark `bg-aubergine` with cream text and rose dividers
  - **Skills & Speaking**: skills panel → aubergine, speaking panel → blush, CTA → rose
  - **Logo carousel**: hot-pink → aubergine (grayscale logos pop against dark)
  - **Footer**: `bg-zinc-800` → `bg-aubergine`, newsletter surface re-themed, MEET TEMITOPE → CONTACT TEMITOPE (→ /contact)
  - **Achievements + About projects**: number badges hot-pink → rose
- **Hero**: kicker now `text-rose`; H1 accent span uses `text-brand-pink` — the intentional one-hero-highlight where #F06 equity survives. Two CTAs updated: **BOOK TEMITOPE TO SPEAK** → `/speaking` and **READ THE HANDBOOK** → `/books`.

### Fonts
- Dropped SK Modernist (only used on `/branding`, which is being refactored soon).
- **Averia + Avenir kept intentionally.** Earlier draft proposed Fraunces; reverted after review. `RULES.md`, `CLAUDE.md` and `REDESIGN.md` updated so future sessions don't re-propose it.
- Migrated the last explicit `font-averia` / `font-avenir` classes (in `achievements.tsx`) to semantic `font-serif` / `font-sans`.

### Nav IA
- New six-item nav: **About · Speaking · Books · Programs · Resources** + **Contact** (button).
- BrandX external link removed. WhatsApp nav button replaced with an in-site Contact button.
- Same six items in the mobile drawer.
- Removed unused `scrollToSection` / `router` from the navbar module.

### Stub pages
- `/speaking`, `/books`, `/programs`, `/resources`, `/contact` all created so nav links resolve.
- Each has a **server-component `layout.tsx`** with unique `title`, `description`, `canonical`, and OG/Twitter cards (matches how `/about` and `/branding` are set up — page bodies remain client components).
- Each stub uses a shared new `<ComingSoon>` component (kicker + serif H1 + intro + CTAs). Every stub links out to a real destination (Selar for the handbook, `mailto:` + WhatsApp for contact, Medium for articles, brandxperience.org for programs) so nothing is a dead end.
- `/branding` kept live; `/programs` currently points visitors there until B3 replaces it.

### SEO
- `sitemap.ts` now lists all 9 canonical routes.

## Test plan

- [ ] `npm run build` — 15 routes generate, no errors (verified in commit).
- [ ] Home hero, testimonials, education, skills panel, logo carousel and footer all read in the new palette without contrast issues.
- [ ] Hero CTAs go to `/speaking` and `/books` (both render the stub).
- [ ] Nav on desktop shows the six items; nav Contact button goes to `/contact`.
- [ ] Mobile drawer shows the six items + Contact.
- [ ] `/speaking`, `/books`, `/programs`, `/resources`, `/contact` all return 200 and render the coming-soon block + navbar + footer.
- [ ] `/sitemap.xml` contains all nine routes.
- [ ] `grep -R "bg-gray-200\|bg-\[#FFD1F7\]\|bg-zinc-800" src/` returns no matches.

## Follow-ups (later Branch B PRs)

- B2 (home rebuild): media bar, impact strip, framework, featured work, book pitch, kill BookModal.
- B3 (about + programs): long-form about, replace `/branding` with a real `/programs`.
- B4 (speaking + books + resources): replace stubs with real content.
- B5 (work + press + contact): case studies, press page, routed contact form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)